### PR TITLE
815.Bus Routes

### DIFF
--- a/t5271688/815.Bus Routes.cpp
+++ b/t5271688/815.Bus Routes.cpp
@@ -1,0 +1,45 @@
+class Solution
+{
+public:
+    int numBusesToDestination(vector<vector<int>> &routes, int source, int target)
+    {
+        if (source == target)
+            return 0;
+        unordered_map<int, vector<int>> m;
+        int length = routes.size();
+        for (int i = 0; i < length; i++)
+        {
+            for (auto curr : routes[i])
+            {
+                m[curr].push_back(i);
+            }
+        }
+        vector<int> visited(length, 0);
+        queue<int> Q;
+        Q.push(source);
+        int result = 0;
+        while (!Q.empty())
+        {
+            int size = Q.size();
+            result++;
+            while (size--)
+            {
+                int curr = Q.front();
+                Q.pop();
+                for (auto i : m[curr])
+                {
+                    if (visited[i])
+                        continue;
+                    visited[i] = 1;
+                    for (auto next : routes[i])
+                    {
+                        if (next == target)
+                            return result;
+                        Q.push(next);
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+};


### PR DESCRIPTION
0-1 BFS
버스 루트를 하나의 정점으로 보고 0-1 BFS 실행 
stop마다 unordered_map으로 stop이 속한 루트를 포함시켜 그래프를 관리

## 복잡도
M=routes.length 
N=routes[i].length 라고 할 때
시간복잡도: O(MN)
공간복잡도: O(MN)?
