### PR TITLE
[#8] 85.Bus Routes

### DIFF
--- a/eehoeskrap/815_bus_routes.py
+++ b/eehoeskrap/815_bus_routes.py
@@ -1,0 +1,49 @@
+from collections import deque
+class Solution(object):
+    def numBusesToDestination(self, routes, source, target):
+
+        if source == target : return 0
+
+        # 각 정류장에서 탈 수 있는 모든 버스 저장
+        # e.g. 7번 정류장 : 0번 버스, 1번 버스
+        #      {1: [0], 2: [0], 3: [1], 6: [1], 7: [0, 1]}
+        stop_dict = {}
+        for bus, stops in enumerate(routes):
+            for stop in stops:
+                if stop not in stop_dict:
+                    stop_dict[stop] = [bus]
+                else:
+                    stop_dict[stop].append(bus)
+
+        queue = deque([source])
+
+        # 이 전에 탔던 버스를 체크
+        visited = set()
+
+        result = 0
+        while queue:
+            result += 1
+            pre_num_stops = len(queue)
+            for _ in range(pre_num_stops):
+                cur_stop = queue.popleft()
+                for bus in stop_dict[cur_stop]:
+                    if bus in visited: continue
+                    visited.add(bus)
+                    for stop in routes[bus]:
+                        if stop == target: return result
+                        queue.append(stop)
+        return -1
+
+if __name__ == '__main__':
+
+    # routes = [[1, 2, 7], [3, 6, 7]]
+    # source = 1
+    # target = 6
+
+    routes = [[0, 1, 6, 16, 22, 23], [14, 15, 24, 32], [4, 10, 12, 20, 24, 28, 33],
+              [1, 10, 11, 19, 27, 33], [11, 23, 25, 28],[15, 20, 21, 23, 29], [29]]
+    source = 4
+    target = 21
+    result = Solution().numBusesToDestination(routes, source, target)
+
+    print(result)


### PR DESCRIPTION
## 접근법
routes에 있는 버스들마다 정류장들을 반복적으로 돌게 되고, 
source 정류장에서 target 정류장까지 가야할 때 버스를 몇 번 타야되는지를 구하는 문제임 

먼저, 각 정류장에서 탈 수 있는 버스들을 stop_dict에 저장하고, queue 구조를 이용하여 현재 자신이 있는 source 정류장 부터 시작해서 현재 머문 정류장에서 탈 수 있는 버스들을 for 문을 이용해서 접근한다.

- 이 때 queue 구조는 deque를 사용한다. 왜냐하면 deque는 앞 뒤로 원소를 뺄 수 있는 자료구조인데, 현재 머문 정류장을 구하기 위해서 pop을 쓸 때 deque에서 popleft는 O(1)의 시간이 걸리지만, queue의 pop(0)은 리스트의 크기에 따라 읽어오는 시간이 달라지며, 이는 O(n)이 걸리기 때문에 **시간 복잡도를 줄이고자 deque 구조를 사용**한다. 

만약 해당 버스를 탄 적이 있다면 continue로 건너 뛰고,
그렇지 않다면 버스 탑승 기록을 visited에 저장한다. 이 때 visited 는 python의 set 자료구조를 이용한다. 
참고로 보통 알고리즘에서 set을 이용하는 이유는 아래와 같다. 

- 삽입과 동시에 정렬이 필요할 때
- 중복을 제거한 원소의 집합이 필요할 때
- 현재 원소가 중복된 값인지 확인이 필요할 때 

이 알고리즘에서 set으로 visited를 관리하는 이유는 **중복을 관리**하기 위해서다. 

그 다음, for문을 돌려서 각 버스가 갈 수 있는 경로에서 해당 정류장이 target 이라면 현재까지 버스 탑승 횟수를 리턴하고, 그게 아니라면 queue에 해당 정류장을 저장한다. 즉 경로를 저장한다. 


## 복잡도

시간복잡도: O(MN) 