### PR TITLE
1235. Maximum Profit in Job Scheduling

### DIFF
--- a/t5271688/1235. Maximum Profit in Job Scheduling.cpp
+++ b/t5271688/1235. Maximum Profit in Job Scheduling.cpp
@@ -1,0 +1,22 @@
+class Solution {
+public:
+//dp + binary search
+    int jobScheduling(vector<int>& startTime, vector<int>& endTime, vector<int>& profit) {
+        vector<vector<int>> V;
+        for (int i = 0; i < startTime.size(); ++i) {
+            V.push_back({ endTime[i], startTime[i], profit[i] });
+        }//종료 시간 기준으로 정렬하기위해 벡터 가장앞에 작업 종료시간이 가도록 새로운 작업 벡터를 구성
+        sort(V.begin(),V.end());//정렬
+        vector<pair<int, int>> dp;// dp 벡터 생성
+        dp.push_back({ 0, 0 });//dp[0]는 아무일도 하지않았을때, 따라서 가중치 0
+        int res = 0;
+         for (int i = 0; i < startTime.size(); ++i) {
+            auto iter = upper_bound(dp.begin(), dp.end(),(pair<int,int>){V[i][1], (int)2e9});//이분탐색으로 현재 작업을 수용할 수 있는 최대의 dp[t]탐색
+            if (iter != dp.begin()) {// 그러한 dp[t]가 있다면
+                res = max(res, prev(iter)->second + V[i][2]);// 리턴값 갱신
+                dp.push_back({ V[i][0], res });// dp 추가 
+            }
+        }
+        return res;
+    }
+};


### PR DESCRIPTION
DP 테이블을 다음과 같이 정의해보자.
Table[x]= 종료 시간 기준으로 정렬된 activity를 x번째까지 고려했을 때, 얻을 수 있는 최대 가중치
Table[0]은 고려할 수 있는 activity가 없으니 0이다.
Table[1]은 당연히 첫번째 Activity의 가중치를 가지게 된다.
Table[2]의 경우에는 1번 Activity만 선택하는 경우, 2번만 선택하는 경우, 1번과 2번을 한번에 선택하는 경우가 있을 수 있다. 이 경우 1번만 선택한다면, 1번까지 고려한 최대의 값인 Table[1]이 되고, 2번만 선택하거나 1번과 2번을 한번에 선택하는 경우는 2번을 선택하고 2번과 겹치지 않는 첫번째 인덱스의 Table값을 취하면 된다. 이를 식으로 표현하면
![xcvbxcv](https://user-images.githubusercontent.com/43768951/175960058-809b815b-765b-46ba-bd15-ce5aeb719ffe.png)

일단 모든 Activity를 finish 기준으로 오름차순 정렬하고(O(nlog n )), n개의 activity에 대해 반복문을 도는데, t를 탐색할 때 O(n)의 시간복잡도가 요구된다. 최종 시간복잡도는
O(n^2)이 된다.
그러나 이 때 모든 activity가 끝나는 순으로 정렬되어있다는 점을 이용해서 t를 탐색할 때 이분 탐색을 이용할 수 있다. 그렇다면 t를 탐색하는데 O(logn)의 시간복잡도가 요구되고 최종 시간복잡도는 O(nlogn)이 된다.

## 복잡도

시간복잡도: O(nlogn)
공간복잡도: O(n)
