### PR TITLE
1235_Maximum Profit in Job Scheduling

### DIFF
--- a/kqt20/1235_Maximum_Profit.java
+++ b/kqt20/1235_Maximum_Profit.java
@@ -1,0 +1,50 @@
+class Solution {
+    public int jobScheduling(int[] startTime, int[] endTime, int[] profit) {
+        int n = profit.length;
+        //startTime, endTime, profit과 같은 인덱스에 profit의 최대값을 저장하는 배열.
+        //가장 초기값을 0으로 만들기 위해 길이를 n+1로 만든다.
+        int[] maxSumsOfProfit = new int[n + 1];
+
+        //문제를 돌리다보면 처음엔 startTime이 오름차순으로 정렬되어있는것처럼 보이다가 뒤에서 정렬이 안되는 케이스들이 나온다.
+        //정렬이 다 되어있는 케이스들도 많으므로 Insertion Sort 를 실행한다.
+        for(int i = 1; i < n; i++){
+            int tmpStart = startTime[i];
+            int tmpEnd = endTime[i];
+            int tmpProfit = profit[i];
+
+            int j = i-1;
+            while(j >= 0 && startTime[j] > tmpStart){
+                //정렬은 startTime만 기준으로 하고, 같은 인덱스에있는 endTime의 값과 profit의 값도 같이 옮겨준다. 
+                startTime[j+1] = startTime[j];
+                endTime[j+1] = endTime[j];
+                profit[j+1] = profit[j];
+                j--;
+            }
+            startTime[j+1] = tmpStart;
+            endTime[j+1] = tmpEnd;
+            profit[j+1] = tmpProfit;
+        }
+
+        for(int i = n - 1; i>=0 ; i--){
+            //안겹치는곳 = startTime[i] , endTime[i] 사이에 startTime을 가지고 있지 않은 가장 먼저 나오는놈
+            // => endTime[i] 보다 값이 크거나 같은 startTime[a]를 찾으면 된다.
+            int notDuplicatedIndex = i+1;
+            while(notDuplicatedIndex < n){
+                //notDuplicatedIndex가 n이 되어도 maxSumOfProfit 배열에서는 상관없지만
+                // startTime의 바운더리는 벗어나게 되므로
+                // while과 if문으로 조건문을 나누어서 OutOfBoundary 오류가 뜨지 않게 한다.
+                if(endTime[i] <= startTime[notDuplicatedIndex])
+                    break;
+                notDuplicatedIndex++;
+            }
+
+            //핵심 코드로, 현재 i보다 전에 계산햇던 최대값 vs 현재 i와 겹치지 않는 최대값 + i의 profit
+            //둘중 더 큰쪽을 계속 저장해 나간다.
+            maxSumsOfProfit[i] = Math.max(maxSumsOfProfit[i + 1],
+                    maxSumsOfProfit[notDuplicatedIndex] + profit[i]);
+        }
+
+        //0에 저장된게 제일 큰 값이므로 리턴
+        return maxSumsOfProfit[0];
+    }
+}


### PR DESCRIPTION
## 접근방법
문제에서 원하는것은 주어진 조건에서 profit의 합이 가장 높게 나오는 것이다.
그러므로 먼저 조건같은건 생각하지 않고, 일단 profit의 합이 가장 높게나오는 함수를 max라고 하자.
그리고 max(i)는 문제에서 주어진 배열의 값  startTime[i], 즉 i번째 시작시간부터 배열의 끝까지만 봤을때 가장 profit이 높게 나온다고 생각하자. (참고로 나는 i를 0부터 시작하지 않고 n부터 시작했는데, 별다른 이유는 없고 그래야할것 같아서 그랬다. 다른 풀이들을 보니 0부터 시작해도 다를건 없는것 같다.)

그러면 다음으로 생각할 것은 어떤게 최대값인가 이다.
우선 i번째 startTime과 endTime은 i+1번째 startTime과 겹칠수가 있다. 겹치면 profit을 더 할수 없으므로 여태까지 지나왔던 인덱스중에 겹치지 않는 인덱스를 찾아서 max값을 찾는다. 그러면 (i+1번째의 max값) vs (겹치지않으면서 가장 가까운 인덱스의 max값 + i번째 profit) 이 둘중 더 큰것이 max(i)가 될 것이다. 이걸 점화식으로 나타낸다면
F(x) = max { F(x+1) , F(previousIndex) + profit[x] } 가 될것이고 이걸 그대로 코드로 옮겨서 문제를 풀었다.

그런데 문제의 답이 틀리길래 무엇이 문제인가 확인해보았더니 문제 자체에서 내주는 테스트 케이스들이 startTime이 오름차순으로 정렬이 되어있지 않다는 것이였다.... 그래서 startTime에 맞게 나머지 배열들도 정렬해 주어서 문제가 해결되었다.


## 복잡도
삽입정렬을 사용했고, 실질적인 로직은 O(n)이 나오므로 시간복잡도는 오로지 정렬이 얼마나 빨리되냐에 달려있다.

시간복잡도: best O(n), worst O(n^2)
공간복잡도: O(n)
