### PR TITLE
Onestep00/dp 4

### DIFF
--- a/onestep00/188. Best Time to Buy and Sell Stock IV.py
+++ b/onestep00/188. Best Time to Buy and Sell Stock IV.py
@@ -1,0 +1,19 @@
+class Solution:
+    def maxProfit(self, k: int, prices: List[int]) -> int:
+        memo = {}
+        
+        def dp(i, transaction, price_sign):
+            if transaction == 0 or i == len(prices):
+                return 0
+            if (i, transaction, price_sign) in memo:
+                return memo[(i, transaction, price_sign)]
+            
+            memo[(i, transaction, price_sign)] = max(
+                dp(i+1, transaction, price_sign), 
+                (price_sign * prices[i])
+                + dp(i+1, transaction-1 if price_sign > 0 else transaction, price_sign * -1)
+            )
+            
+            return memo[(i, transaction, price_sign)]
+        
+        return dp(0, k, -1)

--- a/onestep00/Best Time to Buy and Sell Stock with Cooldown.py
+++ b/onestep00/Best Time to Buy and Sell Stock with Cooldown.py
@@ -1,0 +1,23 @@
+class Solution:
+    def maxProfit(self, prices: List[int]) -> int:
+        memo = {}
+        price_sign = [-1, 1, 0]
+
+        def dp(i, price_sign_index):
+            if i == len(prices):
+                return 0
+            if (i, price_sign_index) in memo:
+                return memo[(i, price_sign_index)]
+
+            memo[(i, price_sign_index)] = max(
+                dp(i + 1, price_sign_index),
+                (price_sign[price_sign_index] * prices[i])
+                + dp(
+                    i + 1,
+                    price_sign_index + 1 if price_sign_index < len(price_sign) - 1 else 0,
+                ),
+            )
+
+            return memo[(i, price_sign_index)]
+
+        return dp(0, 0)


### PR DESCRIPTION
# Best Time to Buy and Sell Stock IV

## 복잡도
n = 총 step
k = 총 transaction

시간복잡도: O(n*k)
공간복잡도: O(n*k)

1. 팔고나서 사야한다는 조건이 붙어있어서 이익 계산 시의 부호 - 팔면 이득을 얻고, 사면 이득 잃음 - 을 바꿔가면서 사고팔고 계산
2. 그냥 안사고 안팔수도있음
둘중에 큰걸로 이어서 계산

memoization으로 중복 탐색 방지
- key : step, transaction, stock status(사기, 팔기)

# Best Time to Buy and Sell Stock with Cooldown

## 복잡도
n = 총 step
k = 총 transaction

시간복잡도: O(n*k)
공간복잡도: O(n*k)

1. 위와 마찬가지지만, 팔면 cooldown을 가져야한다는 조건이 추가됨
    1. 위에서 부호 바꿨던걸 연산 cycle로 변경 - 사기, 팔기, cooldown
2. 그냥 안사고 안팔기
둘중에 큰걸로 이어서 계산

동일하게 memoization
- key : step, status(사기, 팔기, cooldown)